### PR TITLE
Update vcpkg manifest

### DIFF
--- a/SoundRemote.sln
+++ b/SoundRemote.sln
@@ -9,6 +9,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Tests", "Tests\Tests.vcxpro
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject
+		vcpkg-configuration.json = vcpkg-configuration.json
 		vcpkg.json = vcpkg.json
 	EndProjectSection
 EndProject

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,9 +4,6 @@
     "boost-asio",
     "boost-json",
     "simpleini",
-    {
-      "name": "opus",
-      "version>=": "1.5.2"
-    }
+    "opus"
   ]
 }


### PR DESCRIPTION
Removed the minimum version constraint for opus dependency.
Rely on default-registry.baseline in vcpkg-configuration.json instead.