### PR TITLE
Save and restore capture device

### DIFF
--- a/SoundRemote/AudioUtil.h
+++ b/SoundRemote/AudioUtil.h
@@ -24,8 +24,8 @@
 namespace Audio {
 // Constants, types, enums
 
-	constexpr auto defaultRenderDeviceId = -1;
-	constexpr auto defaultCaptureDeviceId = -2;
+	constexpr auto defaultRenderDeviceKey = -1;
+	constexpr auto defaultCaptureDeviceKey = -2;
 
 	enum class Compression { none = 0, kbps_64 = 64'000, kbps_128 = 128'000, kbps_192 = 192'000, kbps_256 = 256'000, kbps_320 = 320'000 };
 

--- a/SoundRemote/AudioUtil.h
+++ b/SoundRemote/AudioUtil.h
@@ -24,9 +24,6 @@
 namespace Audio {
 // Constants, types, enums
 
-	constexpr auto defaultRenderDeviceKey = -1;
-	constexpr auto defaultCaptureDeviceKey = -2;
-
 	enum class Compression { none = 0, kbps_64 = 64'000, kbps_128 = 128'000, kbps_192 = 192'000, kbps_256 = 256'000, kbps_320 = 320'000 };
 
 	namespace Opus {

--- a/SoundRemote/Settings.cpp
+++ b/SoundRemote/Settings.cpp
@@ -11,12 +11,14 @@ namespace Setting {
 	constexpr auto serverPort{ L"server_port" };
 	constexpr auto clientPort{ L"client_port" };
 	constexpr auto checkUpdates{ L"check_updates" };
+	constexpr auto captureDevice{ L"capture_device" };
 }
 
 namespace DefaultValue {
 	constexpr auto serverPort{ Net::defaultServerPort };
 	constexpr auto clientPort{ Net::defaultClientPort };
 	constexpr bool checkUpdates{ true };
+	constexpr auto captureDevice = defaultRenderDeviceId;
 }
 
 Settings::Settings(const std::string& fileName): fileName_(fileName) {
@@ -42,8 +44,17 @@ bool Settings::getCheckUpdates() const {
 	return ini_->GetBoolValue(Section::general, Setting::checkUpdates);
 }
 
+std::wstring Settings::getCaptureDevice() const {
+	return ini_->GetValue(Section::general, Setting::captureDevice);
+}
+
 void Settings::setCheckUpdates(bool check) {
 	ini_->SetBoolValue(Section::general, Setting::checkUpdates, check);
+	ini_->SaveFile(fileName_.c_str());
+}
+
+void Settings::setCaptureDevice(const std::wstring& deviceId) {
+	ini_->SetValue(Section::general, Setting::captureDevice, deviceId.c_str());
 	ini_->SaveFile(fileName_.c_str());
 }
 
@@ -51,6 +62,7 @@ void Settings::setDefaultValues() {
 	ini_->SetLongValue(Section::network, Setting::serverPort, DefaultValue::serverPort);
 	ini_->SetLongValue(Section::network, Setting::clientPort, DefaultValue::clientPort);
 	ini_->SetBoolValue(Section::general, Setting::checkUpdates, DefaultValue::checkUpdates);
+	ini_->SetValue(Section::general, Setting::captureDevice, DefaultValue::captureDevice);
 }
 
 void Settings::checkMissingSettings() {
@@ -71,6 +83,10 @@ void Settings::checkMissingSettings() {
 	}
 	if (!ini_->KeyExists(Section::general, Setting::checkUpdates)) {
 		ini_->SetBoolValue(Section::general, Setting::checkUpdates, DefaultValue::checkUpdates);
+		saveNeeded = true;
+	}
+	if (!ini_->KeyExists(Section::general, Setting::captureDevice)) {
+		ini_->SetValue(Section::general, Setting::captureDevice, DefaultValue::captureDevice);
 		saveNeeded = true;
 	}
 	auto keysWithoutSection = ini_->GetSectionSize(L"");

--- a/SoundRemote/Settings.cpp
+++ b/SoundRemote/Settings.cpp
@@ -3,14 +3,14 @@
 #include "NetDefines.h"
 
 namespace Section {
-	const char* network{ "network" };
-	const char* general{ "general" };
+	const wchar_t* network{ L"network" };
+	const wchar_t* general{ L"general" };
 }
 
 namespace Setting {
-	const char* serverPort{ "server_port" };
-	const char* clientPort{ "client_port" };
-	const char* checkUpdates{ "check_updates" };
+	const wchar_t* serverPort{ L"server_port" };
+	const wchar_t* clientPort{ L"client_port" };
+	const wchar_t* checkUpdates{ L"check_updates" };
 }
 
 namespace DefaultValue {
@@ -18,7 +18,7 @@ namespace DefaultValue {
 }
 
 Settings::Settings(const std::string& fileName): fileName_(fileName) {
-	ini_ = std::make_unique<CSimpleIniA>();
+	ini_ = std::make_unique<CSimpleIniCaseW>();
 	SI_Error rc = ini_->LoadFile(fileName.c_str());
 	if (rc == SI_OK) {
 		checkMissingSettings();
@@ -56,14 +56,14 @@ void Settings::checkMissingSettings() {
 	if (!ini_->KeyExists(Section::network, Setting::serverPort)) {
 		// todo: remove eventually 
 		// Migrate value from version 0.5.2 or older
-		auto serverPort = ini_->GetLongValue("", Setting::serverPort, Net::defaultServerPort);
+		auto serverPort = ini_->GetLongValue(L"", Setting::serverPort, Net::defaultServerPort);
 		ini_->SetLongValue(Section::network, Setting::serverPort, serverPort);
 		saveNeeded = true;
 	}
 	if (!ini_->KeyExists(Section::network, Setting::clientPort)) {
 		// todo: remove eventually 
 		// Migrate value from version 0.5.2 or older
-		auto clientPort = ini_->GetLongValue("", Setting::clientPort, Net::defaultClientPort);
+		auto clientPort = ini_->GetLongValue(L"", Setting::clientPort, Net::defaultClientPort);
 		ini_->SetLongValue(Section::network, Setting::clientPort, clientPort);
 		saveNeeded = true;
 	}
@@ -71,9 +71,9 @@ void Settings::checkMissingSettings() {
 		ini_->SetBoolValue(Section::general, Setting::checkUpdates, DefaultValue::checkUpdates);
 		saveNeeded = true;
 	}
-	auto keysWithoutSection = ini_->GetSectionSize("");
+	auto keysWithoutSection = ini_->GetSectionSize(L"");
 	if (keysWithoutSection > 0) {
-		ini_->Delete("", nullptr);
+		ini_->Delete(L"", nullptr);
 		saveNeeded = true;
 	}
 	if (saveNeeded) {

--- a/SoundRemote/Settings.cpp
+++ b/SoundRemote/Settings.cpp
@@ -48,12 +48,18 @@ std::wstring Settings::getCaptureDevice() const {
 	return ini_->GetValue(Section::general, Setting::captureDevice);
 }
 
-void Settings::setCheckUpdates(bool check) {
-	ini_->SetBoolValue(Section::general, Setting::checkUpdates, check);
+void Settings::setCheckUpdates(bool value) {
+	if (ini_->GetBoolValue(Section::general, Setting::checkUpdates) == value) {
+		return;
+	}
+	ini_->SetBoolValue(Section::general, Setting::checkUpdates, value);
 	ini_->SaveFile(fileName_.c_str());
 }
 
 void Settings::setCaptureDevice(const std::wstring& deviceId) {
+	if (ini_->GetValue(Section::general, Setting::captureDevice) == deviceId) {
+		return;
+	}
 	ini_->SetValue(Section::general, Setting::captureDevice, deviceId.c_str());
 	ini_->SaveFile(fileName_.c_str());
 }

--- a/SoundRemote/Settings.cpp
+++ b/SoundRemote/Settings.cpp
@@ -3,22 +3,24 @@
 #include "NetDefines.h"
 
 namespace Section {
-	const wchar_t* network{ L"network" };
-	const wchar_t* general{ L"general" };
+	constexpr auto network{ L"network" };
+	constexpr auto general{ L"general" };
 }
 
 namespace Setting {
-	const wchar_t* serverPort{ L"server_port" };
-	const wchar_t* clientPort{ L"client_port" };
-	const wchar_t* checkUpdates{ L"check_updates" };
+	constexpr auto serverPort{ L"server_port" };
+	constexpr auto clientPort{ L"client_port" };
+	constexpr auto checkUpdates{ L"check_updates" };
 }
 
 namespace DefaultValue {
+	constexpr auto serverPort{ Net::defaultServerPort };
+	constexpr auto clientPort{ Net::defaultClientPort };
 	constexpr bool checkUpdates{ true };
 }
 
 Settings::Settings(const std::string& fileName): fileName_(fileName) {
-	ini_ = std::make_unique<CSimpleIniCaseW>();
+	ini_ = std::make_unique<CSimpleIniCaseW>(true);
 	SI_Error rc = ini_->LoadFile(fileName.c_str());
 	if (rc == SI_OK) {
 		checkMissingSettings();
@@ -46,8 +48,8 @@ void Settings::setCheckUpdates(bool check) {
 }
 
 void Settings::setDefaultValues() {
-	ini_->SetLongValue(Section::network, Setting::serverPort, Net::defaultServerPort);
-	ini_->SetLongValue(Section::network, Setting::clientPort, Net::defaultClientPort);
+	ini_->SetLongValue(Section::network, Setting::serverPort, DefaultValue::serverPort);
+	ini_->SetLongValue(Section::network, Setting::clientPort, DefaultValue::clientPort);
 	ini_->SetBoolValue(Section::general, Setting::checkUpdates, DefaultValue::checkUpdates);
 }
 
@@ -56,14 +58,14 @@ void Settings::checkMissingSettings() {
 	if (!ini_->KeyExists(Section::network, Setting::serverPort)) {
 		// todo: remove eventually 
 		// Migrate value from version 0.5.2 or older
-		auto serverPort = ini_->GetLongValue(L"", Setting::serverPort, Net::defaultServerPort);
+		auto serverPort = ini_->GetLongValue(L"", Setting::serverPort, DefaultValue::serverPort);
 		ini_->SetLongValue(Section::network, Setting::serverPort, serverPort);
 		saveNeeded = true;
 	}
 	if (!ini_->KeyExists(Section::network, Setting::clientPort)) {
 		// todo: remove eventually 
 		// Migrate value from version 0.5.2 or older
-		auto clientPort = ini_->GetLongValue(L"", Setting::clientPort, Net::defaultClientPort);
+		auto clientPort = ini_->GetLongValue(L"", Setting::clientPort, DefaultValue::clientPort);
 		ini_->SetLongValue(Section::network, Setting::clientPort, clientPort);
 		saveNeeded = true;
 	}

--- a/SoundRemote/Settings.h
+++ b/SoundRemote/Settings.h
@@ -5,14 +5,19 @@
 
 #include <SimpleIni.h>
 
+constexpr auto defaultRenderDeviceId = L"default_playback";
+constexpr auto defaultCaptureDeviceId = L"default_recording";
+
 class Settings {
 public:
 	Settings(const std::string& fileName);
 	int getServerPort() const;
 	int getClientPort() const;
 	bool getCheckUpdates() const;
+	std::wstring getCaptureDevice() const;
 
 	void setCheckUpdates(bool check);
+	void setCaptureDevice(const std::wstring& deviceId);
 
 private:
 	std::string fileName_;

--- a/SoundRemote/Settings.h
+++ b/SoundRemote/Settings.h
@@ -16,7 +16,7 @@ public:
 
 private:
 	std::string fileName_;
-	std::unique_ptr<CSimpleIniA> ini_;
+	std::unique_ptr<CSimpleIniCaseW> ini_;
 
 	void setDefaultValues();
 	void checkMissingSettings();

--- a/SoundRemote/Settings.h
+++ b/SoundRemote/Settings.h
@@ -15,8 +15,17 @@ public:
 	int getClientPort() const;
 	bool getCheckUpdates() const;
 	std::wstring getCaptureDevice() const;
-
-	void setCheckUpdates(bool check);
+	/// <summary>
+	/// Updates the 'check_updates' preference and modifies the file only if the
+	/// new value is different from the current one.
+	/// </summary>
+	/// <param name="value">- to check for updates on startup</param>
+	void setCheckUpdates(bool value);
+	/// <summary>
+	/// Updates the 'capture_device' preference and modifies the file only if the
+	/// new value is different from the current one.
+	/// </summary>
+	/// <param name="deviceId">- device ID</param>
 	void setCaptureDevice(const std::wstring& deviceId);
 
 private:

--- a/SoundRemote/SoundRemoteApp.cpp
+++ b/SoundRemote/SoundRemoteApp.cpp
@@ -147,24 +147,24 @@ void SoundRemoteApp::addDevices(HWND comboBox, EDataFlow flow) {
 void SoundRemoteApp::addDefaultDevice(HWND comboBox, EDataFlow flow) {
     assert(flow == eRender || flow == eCapture);
 
-    int newItemIndex, deviceId;
+    int newItemIndex, deviceKey;
     if (flow == eRender) {
         newItemIndex = ComboBox_AddString(comboBox, defaultRenderDeviceLabel_.data());
-        deviceId = Audio::defaultRenderDeviceId;
+        deviceKey = Audio::defaultRenderDeviceKey;
     } else {
         newItemIndex = ComboBox_AddString(comboBox, defaultCaptureDeviceLabel_.data());
-        deviceId = Audio::defaultCaptureDeviceId;
+        deviceKey = Audio::defaultCaptureDeviceKey;
     }
-    ComboBox_SetItemData(comboBox, newItemIndex, (LPARAM)deviceId);
+    ComboBox_SetItemData(comboBox, newItemIndex, (LPARAM)deviceKey);
 }
 
-std::wstring SoundRemoteApp::getDeviceId(const int deviceIndex) const {
-    if (!deviceIds_.contains(deviceIndex)) {
-        assert(deviceIndex == Audio::defaultCaptureDeviceId || deviceIndex == Audio::defaultRenderDeviceId);
-        EDataFlow flow = (deviceIndex == Audio::defaultCaptureDeviceId) ? eCapture : eRender;
+std::wstring SoundRemoteApp::getDeviceId(const int deviceKey) const {
+    if (!deviceIds_.contains(deviceKey)) {
+        assert(deviceKey == Audio::defaultCaptureDeviceKey || deviceKey == Audio::defaultRenderDeviceKey);
+        EDataFlow flow = (deviceKey == Audio::defaultCaptureDeviceKey) ? eCapture : eRender;
         return Audio::getDefaultDevice(flow);
     }
-    return deviceIds_.at(deviceIndex);
+    return deviceIds_.at(deviceKey);
 }
 
 long SoundRemoteApp::getCharHeight(HWND hWnd) const {
@@ -201,14 +201,14 @@ std::wstring SoundRemoteApp::loadStringResource(UINT resourceId) {
 }
 
 void SoundRemoteApp::onDeviceSelect() {
-// Get selected item's deviceIndex
+// Get selected item's deviceKey
     const auto itemIndex = ComboBox_GetCurSel(deviceComboBox_);
     if (CB_ERR == itemIndex) { return; }
     const auto itemData = ComboBox_GetItemData(deviceComboBox_, itemIndex);
-    const int deviceIndex = static_cast<int>(itemData);
+    const int deviceKey = static_cast<int>(itemData);
 
 // Get device id string
-    const std::wstring deviceId = getDeviceId(deviceIndex);
+    const std::wstring deviceId = getDeviceId(deviceKey);
 
 // Change capture device
     boost::asio::post(ioContext_, std::bind(&SoundRemoteApp::changeCaptureDevice, this, deviceId));

--- a/SoundRemote/SoundRemoteApp.h
+++ b/SoundRemote/SoundRemoteApp.h
@@ -67,8 +67,8 @@ private:
 	void initStrings();
 	void initInterface(HWND hWndParent);
 	void initControls();
-	void startPeakMeter();
-	void stopPeakMeter();
+	void startPeakMeter() const;
+	void stopPeakMeter() const;
 	/// <summary>
 	/// Adds devices for passed <code>EDataFlow</code>, including items for default devices.
 	/// </summary>
@@ -82,6 +82,27 @@ private:
 	/// <param name="flow">Must be EDataFlow::eRender or EDataFlow::eCapture.</param>
 	void addDefaultDevice(HWND comboBox, EDataFlow flow);
 	std::wstring getDeviceId(const int deviceIndex) const;
+	/// <summary>
+	/// Gets device key by its ID.
+	/// Returns <c>invalidDeviceKey</c> if device with such ID could not be found.
+	/// Returns <c>defaultRenderDeviceKey</c> for the default playback ID.
+	/// Returns <c>defaultCaptureDeviceKey</c> for the default recording ID.
+	/// </summary>
+	/// <param name="deviceId">- device ID</param>
+	/// <returns>device key</returns>
+	int getDeviceKey(const std::wstring& deviceId) const;
+	/// <summary>
+	/// Gets saved capture device from the settings and selects it in the device
+	/// combobox.
+	/// </summary>
+	void restoreCaptureDevice();
+	/// <summary>
+	/// Saves capture device to the settings
+	/// </summary>
+	/// <param name="deviceKey">- needed to save special IDs for the default
+	/// playback and default recording devices</param>
+	/// <param name="deviceId">- device system ID</param>
+	void rememberCaptureDevice(int deviceKey, const std::wstring& deviceId);
 	long getCharHeight(HWND hWnd) const;
 
 	// Description:
@@ -92,18 +113,18 @@ private:
 	//   parentWindow - parent window handle.
 	// Returns:
 	//   The handle to the tooltip.
-	HWND setTooltip(HWND toolWindow, PTSTR text, HWND parentWindow);
-	std::wstring loadStringResource(UINT resourceId);
+	HWND setTooltip(HWND toolWindow, PTSTR text, HWND parentWindow) const;
+	std::wstring loadStringResource(UINT resourceId) const;
 	void initSettings();
 	void initMenu();
 
 	// Event handlers
 	void onDeviceSelect();
-	void onClientListUpdate(std::forward_list<std::string> clients);
-	void onClientsUpdate(std::forward_list<ClientInfo> clients);
+	void onClientListUpdate(std::forward_list<std::string> clients) const;
+	void onClientsUpdate(std::forward_list<ClientInfo> clients) const;
 	void onAddressButtonClick() const;
 	void updatePeakMeter();
-	void onReceiveKeystroke(const Keystroke& keystroke);
+	void onReceiveKeystroke(const Keystroke& keystroke) const;
 	void checkUpdates(bool quiet = false);
 	void onUpdateCheckFinish(WPARAM wParam, LPARAM lParam);
 	void visitHomepage() const;

--- a/SoundRemote/SoundRemoteApp.h
+++ b/SoundRemote/SoundRemoteApp.h
@@ -49,7 +49,10 @@ private:
 	std::unique_ptr<MuteButton> muteButton_;
 	// Data
 	std::wstring currentDeviceId_;
-	std::unordered_map<int, std::wstring> deviceIds_;	// <Number stored as data in CombBox items, Device id string>
+	// Device key - number stored as data in select device ComboBox items
+	// to
+	// Device id string
+	std::unordered_map<int, std::wstring> deviceIds_;
 	// Utility
 	boost::asio::io_context ioContext_;
 	std::unique_ptr<std::thread> ioContextThread_;

--- a/Tests/SettingsTest.cpp
+++ b/Tests/SettingsTest.cpp
@@ -4,6 +4,7 @@
 
 #include "pch.h"
 #include "Settings.h"
+#include "NetDefines.h"
 
 namespace {
 
@@ -23,27 +24,43 @@ protected:
 	}
 };
 
-TEST_F(SettingsTest, ServerPort) {
+TEST_F(SettingsTest, ServerPort_default_value) {
+	const std::string iniFile = rootPath + "settings.ini";
+
+	auto settings = Settings(iniFile);
+
+	ASSERT_EQ(Net::defaultServerPort, settings.getServerPort());
+}
+
+TEST_F(SettingsTest, ServerPort_read) {
 	const std::string iniFile = rootPath + "settings.ini";
 
 	int expected = 568;
 	std::ofstream os(iniFile, std::ios::out | std::ios::trunc);
 	ASSERT_TRUE(os.is_open());
-	os << "server_port=" << expected;
+	os << "[network]" << std::endl << "server_port = " << expected;
 	os.close();
-
 	auto settings = Settings(iniFile);
 
 	ASSERT_EQ(expected, settings.getServerPort());
 }
 
-TEST_F(SettingsTest, ClientPort) {
+TEST_F(SettingsTest, ClientPort_default_value) {
+	const std::string iniFile = rootPath + "settings.ini";
+
+	auto settings = Settings(iniFile);
+
+	ASSERT_EQ(Net::defaultClientPort, settings.getClientPort());
+}
+
+
+TEST_F(SettingsTest, ClientPort_read) {
 	const std::string iniFile = rootPath + "settings.ini";
 
 	int expected = 6879;
 	std::ofstream os(iniFile, std::ios::out | std::ios::trunc);
 	ASSERT_TRUE(os.is_open());
-	os << "client_port=" << expected;
+	os << "[network]" << std::endl << "client_port=" << expected;
 	os.close();
 
 	auto settings = Settings(iniFile);
@@ -69,14 +86,16 @@ TEST_F(SettingsTest, Migration) {
 	ASSERT_EQ(expectedClientPort, settings.getClientPort());
 }
 
-TEST_F(SettingsTest, CheckUpdates) {
+TEST_F(SettingsTest, CheckUpdates_default_value) {
 	const std::string iniFile = rootPath + "settings.ini";
 
-	// Set check updates to true in .ini file
-	std::ofstream os(iniFile, std::ios::out | std::ios::trunc);
-	ASSERT_TRUE(os.is_open());
-	os << "check_updates=1";
-	os.close();
+	auto settings = Settings(iniFile);
+
+	ASSERT_TRUE(settings.getCheckUpdates());
+}
+
+TEST_F(SettingsTest, CheckUpdates_write_read) {
+	const std::string iniFile = rootPath + "settings.ini";
 
 	// Change to false with a Settings object
 	Settings(iniFile).setCheckUpdates(false);
@@ -84,6 +103,24 @@ TEST_F(SettingsTest, CheckUpdates) {
 	auto settings = Settings(iniFile);
 
 	ASSERT_FALSE(settings.getCheckUpdates());
+}
+
+TEST_F(SettingsTest, CaptureDevice_default_value) {
+	const std::string iniFile = rootPath + "settings.ini";
+
+	auto settings = Settings(iniFile);
+
+	ASSERT_EQ(L"default_playback", settings.getCaptureDevice());
+}
+
+TEST_F(SettingsTest, CaptureDevice_write_read) {
+	const std::string iniFile = rootPath + "settings.ini";
+	auto expected = std::wstring{ L"expected dev1ce" };
+
+	Settings(iniFile).setCaptureDevice(expected);
+	auto settings = Settings(iniFile);
+
+	ASSERT_EQ(expected, settings.getCaptureDevice());
 }
 
 }


### PR DESCRIPTION
Added a new preference key "capture_device" to persist selected capture device by its system ID.